### PR TITLE
Fix MQTT communication to use flattened topic structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.5] - 2024-11-24
+
+### Fixed
+- **State updates now work with flattened MQTT structure**: Rewrote telegram handler to parse flattened MQTT topics (like device discovery) instead of expecting JSON payloads. State changes from physical switches now properly update entity states in Home Assistant.
+- **Commands now use flattened MQTT structure**: Rewrote command sending to publish individual MQTT messages for each property instead of JSON payloads. Commands are now sent as separate topics like `put/devices/{id}/state/functions/0/key` and `put/devices/{id}/state/functions/0/value`.
+
 ## [0.0.4] - 2024-11-24
 
 ### Fixed

--- a/custom_components/opus_greennet/const.py
+++ b/custom_components/opus_greennet/const.py
@@ -19,6 +19,7 @@ TOPIC_GET_ANSWER_DEVICES: Final = "{base}/{eag_id}/getAnswer/devices/#"
 
 # Subscription patterns (with wildcards)
 TOPIC_SUB_TELEGRAM_FROM: Final = "{base}/{eag_id}/stream/telegram/+/from"
+TOPIC_SUB_TELEGRAM_FROM_ALL: Final = "{base}/{eag_id}/stream/telegram/#"
 TOPIC_SUB_TELEGRAM_TO: Final = "{base}/{eag_id}/stream/telegram/+/to"
 TOPIC_SUB_DEVICE: Final = "{base}/{eag_id}/stream/device/+"
 TOPIC_SUB_DEVICES: Final = "{base}/{eag_id}/stream/devices/+"

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.0.4"
+  "version": "0.0.5"
 }


### PR DESCRIPTION
- Rewrote telegram handler to parse flattened MQTT topics for state updates
- Rewrote command sending to publish individual topic/value pairs
- Removed unused imports (TOPIC_GET_DEVICES, EEP_MAPPINGS, json)
- Added TOPIC_SUB_TELEGRAM_FROM_ALL for wildcard telegram subscription

This fixes both state updates from physical switches and command sending to devices, as the Opus GreenNet bridge uses flattened MQTT structure throughout (not JSON payloads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)