### PR TITLE
fix: Add optimistic state updates for immediate UI feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2026-02-14
+
+### Added
+- **Optimistic state updates**: Lights, switches, and covers now update their state immediately when turned on/off or moved, before waiting for MQTT confirmation. Added `_attr_assumed_state = True` to all controllable entities for instant UI feedback.
+
+## [0.1.4] - 2026-02-14
+
+### Fixed
+- **Device ID to friendly ID lookup in telegram handler**: Fixed `_finalize_telegram` to correctly look up devices using `friendly_id` as the key (matching what's stored in `self.devices`) instead of `device_id` directly. Previously, telegrams arriving before device discovery would create duplicate entries with `friendly_id` as key, while discovered devices used the same key — but the lookup code checked `device_id` and missed matches.
+
+### Changed
+- **Reorganized device data storage**: Split raw MQTT data into separate dictionaries (`_device_data`, `_telegram_data`, `_device_stream_data`) to prevent crosstalk between different message sources.
+
 ## [0.1.3] - 2026-02-14
 
 ### Fixed

--- a/custom_components/opus_greennet/cover.py
+++ b/custom_components/opus_greennet/cover.py
@@ -80,6 +80,7 @@ class OpusGreenNetCover(CoverEntity):
     """Representation of an Opus GreenNet cover (blinds/shades)."""
 
     _attr_has_entity_name = True
+    _attr_assumed_state = True
 
     def __init__(
         self,
@@ -170,12 +171,22 @@ class OpusGreenNetCover(CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
+        # Optimistic state update - update immediately before sending MQTT
+        channel = self._device.get_or_create_channel(self._channel_id)
+        channel.position = 100
+        self.async_write_ha_state()
+
         await self._coordinator.async_set_cover_position(
             self._device.device_id, 100, self._channel_id
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
+        # Optimistic state update - update immediately before sending MQTT
+        channel = self._device.get_or_create_channel(self._channel_id)
+        channel.position = 0
+        self.async_write_ha_state()
+
         await self._coordinator.async_set_cover_position(
             self._device.device_id, 0, self._channel_id
         )
@@ -188,6 +199,11 @@ class OpusGreenNetCover(CoverEntity):
         """Move the cover to a specific position."""
         position = kwargs.get(ATTR_POSITION)
         if position is not None:
+            # Optimistic state update - update immediately before sending MQTT
+            channel = self._device.get_or_create_channel(self._channel_id)
+            channel.position = position
+            self.async_write_ha_state()
+
             await self._coordinator.async_set_cover_position(
                 self._device.device_id, position, self._channel_id
             )
@@ -196,6 +212,11 @@ class OpusGreenNetCover(CoverEntity):
         """Set the cover tilt position."""
         tilt = kwargs.get(ATTR_TILT_POSITION)
         if tilt is not None:
+            # Optimistic state update - update immediately before sending MQTT
+            channel = self._device.get_or_create_channel(self._channel_id)
+            channel.angle = tilt
+            self.async_write_ha_state()
+
             await self._coordinator.async_set_cover_tilt(
                 self._device.device_id, tilt, self._channel_id
             )

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.3"
+  "version": "0.1.5"
 }

--- a/custom_components/opus_greennet/switch.py
+++ b/custom_components/opus_greennet/switch.py
@@ -75,6 +75,7 @@ class OpusGreenNetSwitch(SwitchEntity):
     """Representation of an Opus GreenNet switch."""
 
     _attr_has_entity_name = True
+    _attr_assumed_state = True
 
     def __init__(
         self,
@@ -123,10 +124,20 @@ class OpusGreenNetSwitch(SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
+        # Optimistic state update - update immediately before sending MQTT
+        channel = self._device.get_or_create_channel(self._channel_id)
+        channel.is_on = True
+        self.async_write_ha_state()
+
         await self._coordinator.async_turn_on(self._device.device_id, self._channel_id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
+        # Optimistic state update - update immediately before sending MQTT
+        channel = self._device.get_or_create_channel(self._channel_id)
+        channel.is_on = False
+        self.async_write_ha_state()
+
         await self._coordinator.async_turn_off(self._device.device_id, self._channel_id)
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
This fix adds optimistic state updates to lights, switches, and covers so the UI updates immediately when users interact with entities, before waiting for MQTT confirmation.

## Changes
- Added  to , , and  entities
- Updated / methods to update state immediately before sending MQTT commands
- Updated cover methods (, , , ) for immediate state updates

## Benefits
- Instant UI feedback when turning devices on/off or moving covers
- Better user experience with responsive controls