### PR TITLE
fix: Reduce debounce timer from 100ms to 20ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2026-02-14
+
+### Fixed
+- **Reduced debounce from 100ms to 20ms**: Optimized MQTT message debouncing for both `stream/device` and `stream/telegram` handlers. State changes now propagate faster while still debouncing rapid successive messages.
+
 ## [0.1.5] - 2026-02-14
 
 ### Added

--- a/custom_components/opus_greennet/coordinator.py
+++ b/custom_components/opus_greennet/coordinator.py
@@ -255,9 +255,9 @@ class OpusGreenNetCoordinator:
                 self._finalize_device_stream(did)
 
             # Short debounce: gateway publishes all properties within ms,
-            # so 0.1s is ample to collect a full delta while keeping UI snappy.
+            # so 20ms is ample to collect a full delta while keeping UI snappy.
             self._pending_device_streams[device_id] = async_call_later(
-                self.hass, 0.1, finalize_callback
+                self.hass, 0.02, finalize_callback
             )
 
         except Exception as err:
@@ -596,9 +596,9 @@ class OpusGreenNetCoordinator:
                 self._finalize_telegram(did)
 
             # Short debounce: gateway publishes all properties within ms,
-            # so 0.1s is ample to collect a full telegram while keeping UI snappy.
+            # so 20ms is ample to collect a full telegram while keeping UI snappy.
             self._pending_telegrams[device_id] = async_call_later(
-                self.hass, 0.1, finalize_callback
+                self.hass, 0.02, finalize_callback
             )
 
         except Exception as err:

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.5"
+  "version": "0.1.6"
 }


### PR DESCRIPTION
This fix reduces the debounce timer for MQTT message processing from 100ms to 20ms, enabling faster state updates.

## Changes
- Updated  delay from 0.1 to 0.02 in 
- Updated  delay from 0.1 to 0.02 in 
- Updated comments to reflect 20ms debounce time

## Benefits
- Faster propagation of state changes from MQTT messages
- Reduced latency for device state updates