### PR TITLE
fix: Eliminate duplicate stream processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.8] - 2026-02-14
+
+### Fixed
+- **Eliminated duplicate stream processing**: Modified `_finalize_telegram` to skip state updates for known devices. The `stream/device` topic is now the authoritative source for state updates, while `stream/telegram` is only used for auto-discovering new devices. This prevents duplicate processing when both topics arrive for the same state change.
+
 ## [0.1.7] - 2026-02-14
 
 ### Fixed

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.7"
+  "version": "0.1.8"
 }


### PR DESCRIPTION
This fix eliminates duplicate stream processing by making  the authoritative source for state updates on known devices, while  is only used for auto-discovering new devices.

## Problem
Both  and  topics could arrive for the same state change, causing duplicate processing:
- Both handlers called 
- Both dispatched  signals
- This led to redundant state updates and extra CPU usage

## Solution
- Modified  to skip state updates for known devices
-  is now the single authoritative source for state updates
-  is still used for auto-discovering devices that only send telegrams

## Benefits
- Eliminates duplicate state processing
- Reduces CPU usage from redundant signal dispatching
- Clearer data flow: stream/device = state, stream/telegram = discovery