### PR TITLE
Revert device_id reverse lookup optimization (v0.1.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.9] - 2026-02-14
+
+### Reverted
+- **Reverted device_id reverse lookup optimization**: Removed the `_device_id_to_key` dictionary and restored O(n) linear scans in `_finalize_device_stream` and `_finalize_telegram`. The optimization introduced in v0.1.7 caused issues with device state updates, so we've reverted to the original implementation while keeping the duplicate stream elimination improvements from v0.1.8.
+
 ## [0.1.8] - 2026-02-14
 
 ### Fixed

--- a/custom_components/opus_greennet/coordinator.py
+++ b/custom_components/opus_greennet/coordinator.py
@@ -69,7 +69,6 @@ class OpusGreenNetCoordinator:
         self.hass = hass
         self.eag_id = eag_id
         self.devices: dict[str, EnOceanDevice] = {}
-        self._device_id_to_key: dict[str, str] = {}  # Reverse lookup: device_id -> device_key
         self._device_data: dict[str, dict[str, Any]] = {}  # Raw device properties
         self._telegram_data: dict[str, dict[str, Any]] = {}  # Raw telegram properties
         self._device_stream_data: dict[str, dict[str, Any]] = {}  # Device stream deltas
@@ -273,9 +272,14 @@ class OpusGreenNetCoordinator:
         stream_data = self._device_stream_data.pop(device_id)
         self._pending_device_streams.pop(device_id, None)
 
-        # O(1) lookup using device_id -> device_key mapping
-        device_key = self._device_id_to_key.get(device_id)
-        device = self.devices.get(device_key) if device_key else None
+        # O(n) linear scan to find device by device_id
+        device = None
+        device_key = None
+        for key, dev in self.devices.items():
+            if dev.device_id == device_id:
+                device = dev
+                device_key = key
+                break
 
         if device is None:
             # Device not yet discovered - store for later discovery
@@ -516,7 +520,6 @@ class OpusGreenNetCoordinator:
                 self._apply_initial_state(device, data)
 
             self.devices[device_key] = device
-            self._device_id_to_key[device_id] = device_key
 
             _LOGGER.info(
                 "Device %s: %s (%s) - EEPs: %s - Type: %s",
@@ -657,9 +660,14 @@ class OpusGreenNetCoordinator:
             "telegramInfo": effective_data.get("telegramInfo") or telegram_data.get("telegramInfo", {}),
         }
 
-        # O(1) lookup using device_id -> device_key mapping
-        device_key = self._device_id_to_key.get(device_id)
-        device = self.devices.get(device_key) if device_key else None
+        # O(n) linear scan to find device by device_id
+        device = None
+        device_key = None
+        for key, dev in self.devices.items():
+            if dev.device_id == device_id:
+                device = dev
+                device_key = key
+                break
 
         if device is None:
             # Device not yet discovered - create a basic entry for auto-discovery

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.8"
+  "version": "0.1.9"
 }


### PR DESCRIPTION
This reverts the device_id reverse lookup optimization introduced in v0.1.7 while keeping the duplicate stream elimination changes from v0.1.8.

## Changes
- Remove _device_id_to_key dictionary from coordinator.py __init__
- Restore O(n) linear scan in _finalize_device_stream and _finalize_telegram
- Keep v0.1.8 duplicate stream elimination changes
- Update version to 0.1.9