### PR TITLE
fix: D2-01-11 and D2-01-12 incorrectly treated as single-channel devices

### DIFF
--- a/custom_components/opus_greennet/const.py
+++ b/custom_components/opus_greennet/const.py
@@ -88,8 +88,8 @@ EEP_MAPPINGS: Final = {
     "D2-01-0E": ("switch", "Electronic Switch Actuator, 8 Channels with Energy"),
     "D2-01-0F": ("light", "Dimmer, 8 Channels"),
     "D2-01-10": ("light", "Dimmer, 8 Channels with Energy"),
-    "D2-01-11": ("switch", "Electronic Switch Actuator with Local Control"),
-    "D2-01-12": ("light", "Dimmer with Local Control"),
+    "D2-01-11": ("switch", "Electronic Switch Actuator, 2 Channels with Local Control"),
+    "D2-01-12": ("light", "Dimmer, 2 Channels with Local Control"),
     # Blinds Control (D2-05-xx)
     "D2-05-00": ("cover", "Blinds Control for Position and Angle"),
     "D2-05-01": ("cover", "Blinds Control for Position"),

--- a/custom_components/opus_greennet/enocean_device.py
+++ b/custom_components/opus_greennet/enocean_device.py
@@ -177,6 +177,11 @@ class EnOceanDevice:
             "D2-01-0E": 8,
             "D2-01-0F": 8,
             "D2-01-10": 8,
+            # Local Control variants: same channel count as their non-LC counterparts
+            # D2-01-11 = 2-ch switch with local control (same as D2-01-04/05)
+            # D2-01-12 = 2-ch dimmer with local control (same as D2-01-06/07)
+            "D2-01-11": 2,
+            "D2-01-12": 2,
         }
         return channel_map.get(eep, 1)
 


### PR DESCRIPTION
## Bug

`D2-01-11` (Electronic Switch Actuator with Local Control) and `D2-01-12` (Dimmer with Local Control) are missing from the `channel_count` map in `enocean_device.py`. This causes the integration to create only a **single entity (channel 0)** for these devices.

When HA then calls `turn_on` / `turn_off`, the coordinator sends commands **without a channel field**, which causes the OPUS gateway to default to channel 0. If the physical load is wired to channel 1 (which is common — e.g. rocker A → ch1, rocker B → ch2), HA commands are silently ignored by the device.

## Root cause

The `channel_count` property in `EnOceanDevice` lists multi-channel EEPs explicitly but omits the Local Control variants:

```python
# present
"D2-01-04": 2,  # 2-ch switch
"D2-01-06": 2,  # 2-ch dimmer

# missing → defaults to 1 channel → wrong!
"D2-01-11": ???  # 2-ch switch with local control
"D2-01-12": ???  # 2-ch dimmer with local control
```

## Fix

Add `D2-01-11: 2` and `D2-01-12: 2` to the channel map. Per the EnOcean D2-01 profile specification these EEPs have the same channel count as their non-Local-Control counterparts (`D2-01-04/05` and `D2-01-06/07`).

Also corrects the EEP description strings to explicitly state "2 Channels" for consistency.

## Verified on

- OPUS GreenNet gateway with a `D2-01-11` device (S22, 2-channel switch actuator)
- Gateway MQTT stream confirms `states/0/channel: 1` and `states/1/channel: 0` — two distinct channels
- After fix: integration creates `switch.s22` (ch0) and `switch.s22_ch1` — both independently controllable