### PR TITLE
fix: cover position inversion (OPUS→HA scale)

### DIFF
--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.11"
+  "version": "0.1.10"
 }


### PR DESCRIPTION
## Summary
- Fixes cover position mapping between OPUS and Home Assistant. OPUS uses an inverted scale (0 = fully open, 100 = fully closed) while HA expects 0 = closed, 100 = open. All cover operations now correctly translate between the two.

Fixes #14 and #15

## Changes
- **Cover position inversion**: `current_cover_position` now returns `100 - channel.position` to map OPUS→HA scale
- **Open/close commands**: `async_open_cover` sends position 0 (OPUS open) instead of 100; `async_close_cover` sends 100 (OPUS closed) instead of 0
- **Set position**: `async_set_cover_position` inverts HA position before sending to OPUS
- **Null safety**: Added explicit `None` check for `channel.position`

## Testing
- [ ] `pytest -v` passes (all tests)
- [ ] Manual testing: verify cover open/close/position commands send correct OPUS values

🤖 Generated with [Claude Code](https://claude.com/claude-code)