### PR TITLE
fix(cover): invert position for OPUS Bridge (closes #14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.12] - 2026-03-01
+
+### Fixed
+- **Invert cover position for OPUS Bridge**: OPUS reports 0% = fully open, but Home Assistant expects 0% = fully closed. Position values are now inverted at the HA interface layer. (Closes #14)
+
 ## [0.1.10] - 2026-02-14
 
 ### Reset

--- a/custom_components/opus_greennet/manifest.json
+++ b/custom_components/opus_greennet/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kegelmeier/opus_homeassistant/issues",
   "requirements": [],
-  "version": "0.1.11"
+  "version": "0.1.12"
 }


### PR DESCRIPTION
## Changes

- Invert cover position: OPUS 0%=open → HA expects 0%=closed (already applied in main, this PR adds version bump and changelog)
- Bumps version to 0.1.12
- Adds CHANGELOG entry

Closes #14