### PR TITLE
feat: per-button rocker switch events (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A custom Home Assistant integration for the Opus GreenNet Bridge, enabling contr
 - **Climate control**: HeatArea thermostat support for Valve, CosiTherm, and Electro Heating areas
 - **Sensors**: Humidity, temperature, energy consumption, and signal strength monitoring
 - **Binary sensors**: Window open detection, actuator error states, battery monitoring
-- **Events**: Rocker switch button press/release events
+- **Events**: Per-button rocker switch press/release events (`buttonA0`, `buttonAI`, `buttonB0`, `buttonBI`, `multipleButtons`)
 - **Device services**: ReCom API access for advanced device configuration and diagnostics
 - **UI Configuration**: Set up via Home Assistant's Integrations page
 
@@ -30,7 +30,7 @@ A custom Home Assistant integration for the Opus GreenNet Bridge, enabling contr
 | **Climate** | D1-4B-05, D1-4B-06, D1-4B-07 | OPUS HeatArea thermostats (Valve, CosiTherm, Electro Heating) |
 | **Sensor** | _(from climate devices)_ | Humidity, feed temperature, energy consumption, signal strength |
 | **Binary Sensor** | _(from climate devices)_ | Window open, actuator errors, battery low |
-| **Event** | F6-02-01, F6-02-02, F6-02-03, F6-03-01, F6-03-02 | Rocker switch press/release events |
+| **Event** | F6-02-01, F6-02-02, F6-02-03, F6-03-01, F6-03-02 | Rocker switch press/release events, per button (`buttonA0_pressed`, `buttonA0_released`, …, `multipleButtons_released`) with `button` and `action` event attributes |
 
 ## Prerequisites
 
@@ -213,6 +213,7 @@ tests/
 ├── test_enocean_device.py       # Device model tests
 ├── test_coordinator_helpers.py  # Pure helper and command tests
 ├── test_coordinator_mqtt.py     # MQTT finalization tests
+├── test_event_entity.py         # Rocker switch event entity tests
 └── test_config_flow.py          # Config flow validation tests
 ```
 
@@ -223,7 +224,7 @@ pip install -r requirements_test.txt
 pytest -v
 ```
 
-155 tests run in <0.5s, covering device properties, telegram parsing, command building, MQTT finalization, and config flow validation.
+174 tests run in under 2s, covering device properties, telegram parsing, command building, MQTT finalization, rocker switch events, and config flow validation.
 
 ## License
 

--- a/custom_components/opus_greennet/const.py
+++ b/custom_components/opus_greennet/const.py
@@ -161,6 +161,17 @@ KEY_ACTUATOR_NOT_RESPONDING: Final = "actuatorNotResponding"
 KEY_MISSING_TEMPERATURE: Final = "missingTemperature"
 KEY_CIRCUIT_IN_USE: Final = "circuitInUse"
 
+# Rocker switch button keys (F6-02-xx / F6-03-xx profiles)
+BUTTON_KEYS: Final = (
+    "buttonA0",
+    "buttonAI",
+    "buttonB0",
+    "buttonBI",
+    "multipleButtons",
+)
+BUTTON_VALUE_PRESSED: Final = "pressed"
+BUTTON_VALUE_RELEASED: Final = "released"
+
 # Switch/Light states
 STATE_ON: Final = "on"
 STATE_OFF: Final = "off"
@@ -206,4 +217,5 @@ KNOWN_STATE_KEYS: Final = frozenset({
     "actuatorNotResponding",
     "missingTemperature",
     "circuitInUse",
+    *BUTTON_KEYS,
 })

--- a/custom_components/opus_greennet/enocean_device.py
+++ b/custom_components/opus_greennet/enocean_device.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .const import (
+    BUTTON_KEYS,
     DEFAULT_CHANNEL,
     EEP_MAPPINGS,
     KEY_ACTUATOR_DEACTIVATED,
@@ -65,6 +66,10 @@ class EnOceanChannel:
     actuator_not_responding: str | None = None
     missing_temperature: str | None = None
     circuit_in_use: str | None = None
+    # Transient rocker-switch state: set only by the most recent telegram and
+    # consumed once by the event entity. Reset on every update_from_telegram call.
+    last_button: str | None = None
+    last_button_action: str | None = None
 
 
 @dataclass
@@ -211,12 +216,20 @@ class EnOceanDevice:
 
         channel = self.get_or_create_channel(channel_id)
 
+        # Reset transient rocker fields so they only reflect the current telegram.
+        channel.last_button = None
+        channel.last_button_action = None
+
         # Update channel state from functions
         for func in functions:
             key = func.get("key")
             value = func.get("value")
 
-            if key == KEY_SWITCH:
+            if key in BUTTON_KEYS:
+                channel.last_button = key
+                channel.last_button_action = str(value) if value is not None else None
+
+            elif key == KEY_SWITCH:
                 channel.is_on = value == STATE_ON
 
             elif key == KEY_DIMMER:

--- a/custom_components/opus_greennet/event.py
+++ b/custom_components/opus_greennet/event.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.event import EventEntity
 from homeassistant.config_entries import ConfigEntry
@@ -11,7 +10,13 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_EAG_ID, DOMAIN
+from .const import (
+    BUTTON_KEYS,
+    BUTTON_VALUE_PRESSED,
+    BUTTON_VALUE_RELEASED,
+    CONF_EAG_ID,
+    DOMAIN,
+)
 from .coordinator import (
     SIGNAL_DEVICE_DISCOVERED,
     SIGNAL_DEVICE_STATE_UPDATE,
@@ -21,17 +26,11 @@ from .enocean_device import EnOceanDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-# Event types for rocker switches
-EVENT_TYPE_PRESS = "press"
-EVENT_TYPE_RELEASE = "release"
-EVENT_TYPE_SHORT_PRESS = "short_press"
-EVENT_TYPE_LONG_PRESS = "long_press"
-
-EVENT_TYPES = [
-    EVENT_TYPE_PRESS,
-    EVENT_TYPE_RELEASE,
-    EVENT_TYPE_SHORT_PRESS,
-    EVENT_TYPE_LONG_PRESS,
+# One event type per (button, action) pair, e.g. "buttonA0_pressed".
+EVENT_TYPES: list[str] = [
+    f"{button}_{action}"
+    for button in BUTTON_KEYS
+    for action in (BUTTON_VALUE_PRESSED, BUTTON_VALUE_RELEASED)
 ]
 
 
@@ -126,20 +125,23 @@ class OpusGreenNetEvent(EventEntity):
         """Handle state update from coordinator - fire event."""
         self._device = device
 
-        # Extract event data from the latest telegram functions
-        # Rocker switches typically send button action data
         channel = device.channels.get(0)
         if not channel:
             return
 
-        # Determine event type from device state
-        # The exact mapping depends on the gateway's telegram format for F6 profiles
-        event_data: dict[str, Any] = {}
+        button = channel.last_button
+        action = channel.last_button_action
+        if not button or not action:
+            return
 
-        if channel.is_on:
-            event_type = EVENT_TYPE_PRESS
-        else:
-            event_type = EVENT_TYPE_RELEASE
+        event_type = f"{button}_{action}"
+        if event_type not in EVENT_TYPES:
+            _LOGGER.debug(
+                "Ignoring unknown rocker event %s for device %s",
+                event_type,
+                self._device_key,
+            )
+            return
 
-        self._trigger_event(event_type, event_data)
+        self._trigger_event(event_type, {"button": button, "action": action})
         self.async_write_ha_state()

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -219,3 +219,16 @@ class TestCommandBuilding:
         coordinator.async_send_command.assert_called_once_with(
             "DEV1", [{"key": "query", "value": "status"}]
         )
+
+
+# ── KNOWN_STATE_KEYS ───────────────────────────────────────────────────
+
+
+class TestKnownStateKeys:
+    """Regression guards for KNOWN_STATE_KEYS membership."""
+
+    def test_includes_rocker_button_keys(self):
+        from custom_components.opus_greennet.const import BUTTON_KEYS, KNOWN_STATE_KEYS
+
+        for key in BUTTON_KEYS:
+            assert key in KNOWN_STATE_KEYS, f"{key} missing from KNOWN_STATE_KEYS"

--- a/tests/test_enocean_device.py
+++ b/tests/test_enocean_device.py
@@ -310,6 +310,43 @@ class TestUpdateFromTelegram:
         assert ch.is_on is True
         assert ch.brightness == 80
 
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("buttonA0", "pressed"),
+            ("buttonA0", "released"),
+            ("buttonAI", "pressed"),
+            ("buttonB0", "pressed"),
+            ("buttonBI", "released"),
+            ("multipleButtons", "pressed"),
+        ],
+    )
+    def test_rocker_button_recorded(self, make_telegram, key, value):
+        dev = self._device()
+        dev.update_from_telegram(make_telegram([{"key": key, "value": value}]))
+        ch = dev.channels[0]
+        assert ch.last_button == key
+        assert ch.last_button_action == value
+
+    def test_rocker_button_cleared_on_next_non_button_telegram(self, make_telegram):
+        dev = self._device()
+        dev.update_from_telegram(make_telegram([{"key": "buttonA0", "value": "pressed"}]))
+        assert dev.channels[0].last_button == "buttonA0"
+
+        dev.update_from_telegram(make_telegram([{"key": "switch", "value": "on"}]))
+        ch = dev.channels[0]
+        assert ch.last_button is None
+        assert ch.last_button_action is None
+        assert ch.is_on is True
+
+    def test_rocker_button_overwritten_on_next_button_telegram(self, make_telegram):
+        dev = self._device()
+        dev.update_from_telegram(make_telegram([{"key": "buttonA0", "value": "pressed"}]))
+        dev.update_from_telegram(make_telegram([{"key": "buttonB0", "value": "released"}]))
+        ch = dev.channels[0]
+        assert ch.last_button == "buttonB0"
+        assert ch.last_button_action == "released"
+
 
 # ── from_device_object ─────────────────────────────────────────────────
 

--- a/tests/test_event_entity.py
+++ b/tests/test_event_entity.py
@@ -1,0 +1,92 @@
+"""Tests for the OpusGreenNetEvent entity (rocker switch events)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.opus_greennet.const import BUTTON_KEYS
+from custom_components.opus_greennet.enocean_device import EnOceanChannel, EnOceanDevice
+from custom_components.opus_greennet.event import EVENT_TYPES, OpusGreenNetEvent
+
+
+@pytest.fixture
+def rocker_device():
+    return EnOceanDevice(
+        device_id="ROCKER1",
+        friendly_id="Living Room Rocker",
+        eeps=[{"eep": "F6-02-01"}],
+    )
+
+
+@pytest.fixture
+def event_entity(rocker_device):
+    entity = OpusGreenNetEvent(
+        coordinator=MagicMock(),
+        eag_id="AABB0011",
+        device=rocker_device,
+    )
+    entity._trigger_event = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+def test_event_types_cover_all_button_action_combinations():
+    expected = {f"{b}_{a}" for b in BUTTON_KEYS for a in ("pressed", "released")}
+    assert set(EVENT_TYPES) == expected
+    assert len(EVENT_TYPES) == len(expected)
+
+
+@pytest.mark.parametrize(
+    "button,action",
+    [
+        ("buttonA0", "pressed"),
+        ("buttonA0", "released"),
+        ("buttonAI", "pressed"),
+        ("buttonB0", "released"),
+        ("buttonBI", "pressed"),
+        ("multipleButtons", "pressed"),
+    ],
+)
+def test_fires_event_for_each_button_action(event_entity, rocker_device, button, action):
+    rocker_device.channels[0] = EnOceanChannel(
+        channel_id=0,
+        last_button=button,
+        last_button_action=action,
+    )
+
+    event_entity._handle_state_update(rocker_device)
+
+    event_entity._trigger_event.assert_called_once_with(
+        f"{button}_{action}", {"button": button, "action": action}
+    )
+    event_entity.async_write_ha_state.assert_called_once()
+
+
+def test_no_event_when_button_fields_unset(event_entity, rocker_device):
+    rocker_device.channels[0] = EnOceanChannel(channel_id=0)
+
+    event_entity._handle_state_update(rocker_device)
+
+    event_entity._trigger_event.assert_not_called()
+    event_entity.async_write_ha_state.assert_not_called()
+
+
+def test_no_event_when_no_channel(event_entity, rocker_device):
+    rocker_device.channels.clear()
+
+    event_entity._handle_state_update(rocker_device)
+
+    event_entity._trigger_event.assert_not_called()
+
+
+def test_no_event_for_unknown_button_action(event_entity, rocker_device):
+    rocker_device.channels[0] = EnOceanChannel(
+        channel_id=0,
+        last_button="buttonA0",
+        last_button_action="held",  # not in pressed/released
+    )
+
+    event_entity._handle_state_update(rocker_device)
+
+    event_entity._trigger_event.assert_not_called()


### PR DESCRIPTION
## Summary
- Closes #18: rocker switch events now identify the actual physical button (`buttonA0`, `buttonAI`, `buttonB0`, `buttonBI`, `multipleButtons`).
- One `event_type` per (button, action) pair (e.g. `buttonA0_pressed`), with `button` and `action` also surfaced in event attributes.
- Fixes the latent bug where the entity fired generic `press`/`release` off `channel.is_on`, which `F6-*` telegrams never set.

## Changes
- `const.py`: add `BUTTON_KEYS`, `BUTTON_VALUE_PRESSED`/`RELEASED`; include button keys in `KNOWN_STATE_KEYS` so deltas aren't filtered out.
- `enocean_device.py`: add transient `last_button` / `last_button_action` on `EnOceanChannel`; populated when a button key arrives and reset on every telegram so a stale value never refires.
- `event.py`: `EVENT_TYPES` generated as `BUTTON_KEYS × {pressed, released}`; `_handle_state_update` reads the transient fields and fires `f"{button}_{action}"` with `{"button": ..., "action": ...}` attributes; returns early when no button info or for unknown action values.
- Tests: button recording + transient-field reset, event entity dispatch matrix, no-event guards (no channel, no button, unknown action), and a `KNOWN_STATE_KEYS` regression check.
- README: feature bullet, supported devices row, test layout, and test count updated.

## Caveats
- **Breaking change for any automation listening to the old generic `press`/`release` types** — but those carried no button info and couldn't reliably trigger anything specific. Worth a CHANGELOG note on the next release.
- `_finalize_telegram` debounces at 20 ms; two very fast independent presses on the same button could be merged into one telegram. Out of scope here.
- Long-press detection deferred — the gateway only emits `pressed`/`released`; would need a timer in HA.

## Testing
- [x] `pytest -v` passes (174 tests, 16 new)
- [ ] Manual test on a physical 4-rocker (F6-02-01 / F6-03-01): trigger each button, confirm distinct `event_type` and `event_attributes` in HA's Developer Tools → Events.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tQQsZBMFJyqiGBhVybRjv)_