### PR TITLE
fix: handle command acknowledgements and stale channel entities

### DIFF
--- a/custom_components/opus_greennet/coordinator.py
+++ b/custom_components/opus_greennet/coordinator.py
@@ -472,7 +472,7 @@ class OpusGreenNetCoordinator:
 
     @callback
     def _handle_put_answer_state(self, msg: ReceiveMessage) -> None:
-        """Handle the protocol's asynchronous command-error response."""
+        """Handle the protocol's asynchronous command acknowledgement."""
         match = PUT_ANSWER_STATE_TOPIC_PATTERN.fullmatch(msg.topic)
         if not match or match.group(1) != self.eag_id:
             return
@@ -483,10 +483,34 @@ class OpusGreenNetCoordinator:
             if isinstance(msg.payload, bytes)
             else str(msg.payload)
         )
+
+        status: int | None = None
+        try:
+            response = json.loads(payload)
+            if isinstance(response, dict):
+                header = response.get("header")
+                if isinstance(header, dict):
+                    status = int(header["httpStatus"])
+        except json.JSONDecodeError, KeyError, TypeError, ValueError:
+            pass
+
+        device = self.get_device(device_id)
+        if status is not None and 200 <= status < 300:
+            _LOGGER.debug(
+                "OPUS command accepted for %s with HTTP status %d",
+                device_id,
+                status,
+            )
+            if device is not None and device.last_command_error is not None:
+                device.last_command_error = None
+                signal = f"{SIGNAL_DEVICE_STATE_UPDATE}_{self.eag_id}_{device_id}"
+                async_dispatcher_send(self.hass, signal, device)
+            return
+
         error = payload or "Gateway rejected the state command"
         _LOGGER.warning("OPUS command failed for %s: %s", device_id, error)
 
-        if (device := self.get_device(device_id)) is None:
+        if device is None:
             return
 
         device.last_command_error = error

--- a/custom_components/opus_greennet/entity.py
+++ b/custom_components/opus_greennet/entity.py
@@ -7,6 +7,7 @@ import logging
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .const import DOMAIN
 from .coordinator import SIGNAL_DEVICE_STATE_UPDATE, OpusGreenNetCoordinator
@@ -14,6 +15,48 @@ from .diagnostics import log_entity_state_write
 from .enocean_device import EnOceanDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def migrate_legacy_multichannel_entity(
+    entity_registry: EntityRegistry,
+    entity_domain: str,
+    eag_id: str,
+    device: EnOceanDevice,
+) -> None:
+    """Migrate or remove a stale single-channel registry entry."""
+    if device.channel_count <= 1:
+        return
+
+    legacy_unique_id = f"{eag_id}_{device.device_id}"
+    channel_zero_unique_id = f"{legacy_unique_id}_ch0"
+    legacy_entity_id = entity_registry.async_get_entity_id(
+        entity_domain, DOMAIN, legacy_unique_id
+    )
+    if legacy_entity_id is None:
+        return
+
+    channel_zero_entity_id = entity_registry.async_get_entity_id(
+        entity_domain, DOMAIN, channel_zero_unique_id
+    )
+    if channel_zero_entity_id is not None:
+        entity_registry.async_remove(legacy_entity_id)
+        _LOGGER.info(
+            "Removed obsolete aggregate entity %s; channel 0 is %s",
+            legacy_entity_id,
+            channel_zero_entity_id,
+        )
+        return
+
+    entity_registry.async_update_entity(
+        legacy_entity_id,
+        new_unique_id=channel_zero_unique_id,
+    )
+    _LOGGER.info(
+        "Migrated legacy entity %s to multi-channel unique ID %s",
+        legacy_entity_id,
+        channel_zero_unique_id,
+    )
 
 
 class OpusGreenNetEntity(Entity):

--- a/custom_components/opus_greennet/light.py
+++ b/custom_components/opus_greennet/light.py
@@ -9,7 +9,11 @@ from homeassistant.components.light import (
     ColorMode,
     LightEntity,
 )
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+)
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -20,7 +24,7 @@ from .coordinator import (
     OpusGreenNetCoordinator,
 )
 from .enocean_device import EnOceanDevice
-from .entity import OpusGreenNetEntity
+from .entity import OpusGreenNetEntity, migrate_legacy_multichannel_entity
 
 
 async def async_setup_entry(
@@ -32,12 +36,20 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     gateway_device_id = entry.runtime_data.gateway_device_id
     eag_id = entry.data[CONF_EAG_ID]
+    entity_registry = er.async_get(hass)
 
     @callback
     def async_add_light(device: EnOceanDevice) -> None:
         """Add a light entity for a discovered device."""
         if device.entity_type != "light":
             return
+
+        migrate_legacy_multichannel_entity(
+            entity_registry,
+            LIGHT_DOMAIN,
+            eag_id,
+            device,
+        )
 
         # Create entity for each channel
         entities = []

--- a/custom_components/opus_greennet/switch.py
+++ b/custom_components/opus_greennet/switch.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -16,7 +18,7 @@ from .coordinator import (
     OpusGreenNetCoordinator,
 )
 from .enocean_device import EnOceanDevice
-from .entity import OpusGreenNetEntity
+from .entity import OpusGreenNetEntity, migrate_legacy_multichannel_entity
 
 
 async def async_setup_entry(
@@ -28,12 +30,20 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
     gateway_device_id = entry.runtime_data.gateway_device_id
     eag_id = entry.data[CONF_EAG_ID]
+    entity_registry = er.async_get(hass)
 
     @callback
     def async_add_switch(device: EnOceanDevice) -> None:
         """Add a switch entity for a discovered device."""
         if device.entity_type != "switch":
             return
+
+        migrate_legacy_multichannel_entity(
+            entity_registry,
+            SWITCH_DOMAIN,
+            eag_id,
+            device,
+        )
 
         # Create entity for each channel
         entities = []

--- a/tests/test_coordinator_mqtt.py
+++ b/tests/test_coordinator_mqtt.py
@@ -364,6 +364,57 @@ class TestAnswerMessages:
         assert coord._device_data["DEV1"]["friendlyId"] == "Wrapped switch"
         assert "DEV1" in coord._pending_devices
 
+    @pytest.mark.parametrize("status", [200, 201])
+    def test_put_answer_accepts_success_status(self, coord, status):
+        """Successful acknowledgements clear errors without stopping retries."""
+        cancel = MagicMock()
+        coord.devices["DEV1"] = EnOceanDevice(
+            device_id="DEV1",
+            friendly_id="Switch",
+            eeps=[{"eep": "D2-01-00"}],
+        )
+        coord.devices["DEV1"].last_command_error = "previous failure"
+        coord._pending_reconciliation_queries[("DEV1", 0)] = [cancel]
+        msg = SimpleNamespace(
+            topic="EnOcean/AABB0011/putAnswer/devices/DEV1/state",
+            payload=json.dumps({"header": {"httpStatus": status}}).encode(),
+        )
+
+        with (
+            patch(
+                "custom_components.opus_greennet.coordinator.async_dispatcher_send"
+            ) as mock_dispatch,
+            patch(
+                "custom_components.opus_greennet.coordinator._LOGGER.warning"
+            ) as mock_warning,
+        ):
+            coord._handle_put_answer_state(msg)
+
+        assert coord.devices["DEV1"].last_command_error is None
+        cancel.assert_not_called()
+        assert ("DEV1", 0) in coord._pending_reconciliation_queries
+        mock_dispatch.assert_called_once()
+        mock_warning.assert_not_called()
+
+    def test_put_answer_records_structured_error_status(self, coord):
+        """A non-success status remains visible as a command failure."""
+        coord.devices["DEV1"] = EnOceanDevice(
+            device_id="DEV1",
+            friendly_id="Switch",
+            eeps=[{"eep": "D2-01-00"}],
+        )
+        payload = json.dumps(
+            {"header": {"httpStatus": 400}, "error": "invalid command"}
+        )
+        msg = SimpleNamespace(
+            topic="EnOcean/AABB0011/putAnswer/devices/DEV1/state",
+            payload=payload.encode(),
+        )
+
+        coord._handle_put_answer_state(msg)
+
+        assert coord.devices["DEV1"].last_command_error == payload
+
     def test_put_answer_records_error_and_cancels_reconciliation(self, coord):
         """A gateway command error is exposed in diagnostics and stops retries."""
         cancel = MagicMock()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -35,6 +35,9 @@ from custom_components.opus_greennet.enocean_device import (
     EnOceanChannel,
     EnOceanDevice,
 )
+from custom_components.opus_greennet.entity import (
+    migrate_legacy_multichannel_entity,
+)
 from custom_components.opus_greennet.event import (
     async_setup_entry as async_setup_events,
 )
@@ -270,6 +273,57 @@ def test_binary_sensor_values() -> None:
     assert window.is_on is True
     assert problem.is_on is True
     assert battery.is_on is False
+
+
+def test_removes_obsolete_aggregate_when_channel_zero_exists() -> None:
+    registry = MagicMock()
+    registry.async_get_entity_id.side_effect = [
+        "switch.test_device",
+        "switch.test_device_channel_0",
+    ]
+
+    migrate_legacy_multichannel_entity(
+        registry,
+        "switch",
+        EAG_ID,
+        _device("D2-01-11"),
+    )
+
+    registry.async_remove.assert_called_once_with("switch.test_device")
+    registry.async_update_entity.assert_not_called()
+
+
+def test_migrates_legacy_entity_when_channel_zero_is_missing() -> None:
+    registry = MagicMock()
+    registry.async_get_entity_id.side_effect = ["switch.test_device", None]
+
+    migrate_legacy_multichannel_entity(
+        registry,
+        "switch",
+        EAG_ID,
+        _device("D2-01-11"),
+    )
+
+    registry.async_update_entity.assert_called_once_with(
+        "switch.test_device",
+        new_unique_id=f"{EAG_ID}_DEV1_ch0",
+    )
+    registry.async_remove.assert_not_called()
+
+
+def test_keeps_single_channel_registry_entity() -> None:
+    registry = MagicMock()
+
+    migrate_legacy_multichannel_entity(
+        registry,
+        "switch",
+        EAG_ID,
+        _device("D2-01-01"),
+    )
+
+    registry.async_get_entity_id.assert_not_called()
+    registry.async_remove.assert_not_called()
+    registry.async_update_entity.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat OPUS `putAnswer` messages as acknowledgements so successful gateway responses are no longer reported as command failures
- Clean up obsolete aggregate registry entities left behind for multi-channel actuators

## Changes
- Accept HTTP 200 and 201 acknowledgement responses without cancelling state reconciliation
- Clear a previous command error after a successful acknowledgement
- Preserve a legacy entity as channel 0 when no channel-0 entry exists
- Remove only the obsolete aggregate entry when a channel-0 entry already exists
- Apply the registry migration to multi-channel switch and light devices
- Add regression coverage for success/error acknowledgements and registry migration behavior

## Testing
- [x] `pytest -v --cov --cov-report=term-missing` passes (215 tests, 76.05% coverage)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [ ] Manual testing on h11 after the beta is installed
