### PR TITLE
feat: add F6-05-01 leak detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A custom Home Assistant integration for the Opus GreenNet Bridge, enabling contr
 - **Bidirectional control**: Send commands to actuators (lights, switches, covers, thermostats)
 - **Climate control**: HeatArea thermostat support for Valve, CosiTherm, and Electro Heating areas
 - **Sensors**: Humidity, temperature, power consumption, and signal strength monitoring
-- **Binary sensors**: Window open detection, actuator error states, battery monitoring
+- **Binary sensors**: Water leak detection, window open detection, actuator error states, battery monitoring
 - **Events**: Per-button rocker switch press/release events (`buttonA0`, `buttonAI`, `buttonB0`, `buttonBI`, `multipleButtons`)
 - **Device services**: ReCom API access for advanced device configuration and diagnostics
 - **UI Configuration**: Set up via Home Assistant's Integrations page
@@ -40,7 +40,7 @@ A custom Home Assistant integration for the Opus GreenNet Bridge, enabling contr
 | **Cover** | D2-05-00, D2-05-01, D2-05-02 | Blinds, shades, and shutters |
 | **Climate** | D1-4B-05, D1-4B-06, D1-4B-07 | OPUS HeatArea thermostats (Valve, CosiTherm, Electro Heating) |
 | **Sensor** | _(from climate devices)_ | Humidity, feed temperature, power consumption, signal strength |
-| **Binary Sensor** | _(from climate devices)_ | Window open, actuator errors, battery low |
+| **Binary Sensor** | F6-05-01, _(from climate devices)_ | Water leak detection, window open, actuator errors, battery low |
 | **Event** | F6-02-01, F6-02-02, F6-02-03, F6-03-01, F6-03-02 | Rocker switch press/release events, per button (`buttonA0_pressed`, `buttonA0_released`, …, `multipleButtons_released`) with `button` and `action` event attributes |
 
 ## Prerequisites

--- a/custom_components/opus_greennet/binary_sensor.py
+++ b/custom_components/opus_greennet/binary_sensor.py
@@ -34,10 +34,22 @@ async def async_setup_entry(
     @callback
     def async_add_binary_sensors(device: EnOceanDevice) -> None:
         """Add binary sensor entities for a discovered device."""
-        if not device.is_climate:
-            return
-
         entities: list[BinarySensorEntity] = []
+
+        if device.primary_eep == "F6-05-01":
+            entities.append(
+                OpusGreenNetMoistureSensor(
+                    coordinator=coordinator,
+                    eag_id=eag_id,
+                    gateway_device_id=gateway_device_id,
+                    device=device,
+                )
+            )
+
+        if not device.is_climate:
+            if entities:
+                async_add_entities(entities)
+            return
 
         # Window open (all HeatArea types)
         entities.append(
@@ -172,6 +184,37 @@ class OpusGreenNetWindowSensor(OpusGreenNetBaseBinarySensor):
         channel = self._device.channels.get(DEFAULT_CHANNEL)
         if channel:
             return channel.window_open
+        return None
+
+
+class OpusGreenNetMoistureSensor(OpusGreenNetBaseBinarySensor):
+    """Water leak binary sensor for F6-05-01 devices."""
+
+    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+
+    def __init__(
+        self,
+        coordinator: OpusGreenNetCoordinator,
+        eag_id: str,
+        gateway_device_id: str,
+        device: EnOceanDevice,
+    ) -> None:
+        """Initialize the moisture sensor."""
+        super().__init__(
+            coordinator,
+            eag_id,
+            gateway_device_id,
+            device,
+            "liquid_detected",
+            "water_leak",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true when liquid is detected."""
+        channel = self._device.channels.get(DEFAULT_CHANNEL)
+        if channel:
+            return channel.liquid_detected
         return None
 
 

--- a/custom_components/opus_greennet/const.py
+++ b/custom_components/opus_greennet/const.py
@@ -108,6 +108,8 @@ EEP_MAPPINGS: Final = {
     # 4-Button Switch (F6-03-xx)
     "F6-03-01": ("event", "Rocker Switch, 4 Rocker"),
     "F6-03-02": ("event", "Rocker Switch, 4 Rocker"),
+    # Liquid Leakage Sensor (F6-05-01)
+    "F6-05-01": ("binary_sensor", "Liquid Leakage Sensor"),
 }
 
 # Entity type to platform mapping
@@ -116,6 +118,7 @@ ENTITY_PLATFORMS: Final = {
     "switch": "switch",
     "cover": "cover",
     "climate": "climate",
+    "binary_sensor": "binary_sensor",
     "event": "event",
 }
 
@@ -128,6 +131,7 @@ KEY_CHANNEL: Final = "channel"
 KEY_LOCAL_CONTROL: Final = "localControl"
 KEY_ENERGY: Final = "energy"
 KEY_POWER: Final = "power"
+KEY_LIQUID_DETECTED: Final = "liquidDetected"
 
 # Climate function keys
 KEY_TEMPERATURE: Final = "temperature"
@@ -191,6 +195,7 @@ KNOWN_STATE_KEYS: Final = frozenset(
         "localControl",
         "energy",
         "power",
+        "liquidDetected",
         "temperature",
         "temperatureSetpoint",
         "heaterMode",

--- a/custom_components/opus_greennet/enocean_device.py
+++ b/custom_components/opus_greennet/enocean_device.py
@@ -21,6 +21,7 @@ from .const import (
     KEY_FEED_TEMPERATURE,
     KEY_HEATER_MODE,
     KEY_HUMIDITY,
+    KEY_LIQUID_DETECTED,
     KEY_LOCAL_CONTROL,
     KEY_MISSING_TEMPERATURE,
     KEY_POSITION,
@@ -49,6 +50,7 @@ class EnOceanChannel:
     local_control: bool = False
     energy: float | None = None
     power: float | None = None
+    liquid_detected: bool | None = None
     # Climate fields
     temperature: float | None = None
     temperature_setpoint: float | None = None
@@ -220,6 +222,19 @@ class EnOceanDevice:
             except ValueError, TypeError:
                 return DEFAULT_CHANNEL
 
+    @staticmethod
+    def _parse_boolean(value: Any) -> bool | None:
+        """Parse an explicit boolean without guessing from malformed values."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized == "true":
+                return True
+            if normalized == "false":
+                return False
+        return None
+
     def update_from_telegram(self, telegram: dict[str, Any]) -> None:
         """Update device state from a telegram message."""
         functions = telegram.get("functions", [])
@@ -293,6 +308,11 @@ class EnOceanDevice:
                     channel.power = float(value)
                 except ValueError, TypeError:
                     pass
+
+            elif key == KEY_LIQUID_DETECTED:
+                liquid_detected = self._parse_boolean(value)
+                if liquid_detected is not None:
+                    channel.liquid_detected = liquid_detected
 
             # Climate keys
             elif key == KEY_TEMPERATURE:

--- a/custom_components/opus_greennet/translations/en.json
+++ b/custom_components/opus_greennet/translations/en.json
@@ -39,6 +39,9 @@
       "missing_temperature": {
         "name": "Missing temperature"
       },
+      "water_leak": {
+        "name": "Water leak"
+      },
       "window": {
         "name": "Window"
       }

--- a/tests/test_coordinator_helpers.py
+++ b/tests/test_coordinator_helpers.py
@@ -242,3 +242,11 @@ class TestKnownStateKeys:
 
         for key in BUTTON_KEYS:
             assert key in KNOWN_STATE_KEYS, f"{key} missing from KNOWN_STATE_KEYS"
+
+    def test_includes_liquid_detected(self):
+        from custom_components.opus_greennet.const import (
+            KEY_LIQUID_DETECTED,
+            KNOWN_STATE_KEYS,
+        )
+
+        assert KEY_LIQUID_DETECTED in KNOWN_STATE_KEYS

--- a/tests/test_coordinator_mqtt.py
+++ b/tests/test_coordinator_mqtt.py
@@ -55,6 +55,27 @@ class TestFinalizeTelegram:
         assert device.last_update_source == "stream/telegram/from"
         assert device.last_update_dispatched_monotonic is not None
 
+    def test_applies_liquid_detection_from_from_subkey(self, coord):
+        """F6-05-01 telegrams update the moisture state through the live path."""
+        coord._telegram_data["LEAK1"] = {
+            "deviceId": "LEAK1",
+            "from": {
+                "friendlyId": "Utility room leak sensor",
+                "functions": [{"key": "liquidDetected", "value": True}],
+            },
+        }
+        coord.devices["LEAK1"] = EnOceanDevice(
+            device_id="LEAK1",
+            friendly_id="Utility room leak sensor",
+            eeps=[{"eep": "F6-05-01"}],
+        )
+
+        coord._finalize_telegram("LEAK1")
+
+        device = coord.devices["LEAK1"]
+        assert device.channels[0].liquid_detected is True
+        assert device.last_update_source == "stream/telegram/from"
+
     def test_applies_to_only_state_command(self, coord):
         """Outbound command telegrams are used as optimistic state updates."""
         coord._telegram_data["DEV1"] = {
@@ -711,6 +732,22 @@ class TestFinalizeDiscovery:
         ch = dev.channels[0]
         assert ch.is_on is True
         assert ch.brightness == 60
+
+    def test_applies_initial_liquid_state(self, coord):
+        """Discovery restores a valid retained F6-05-01 state."""
+        coord._device_data["LEAK1"] = {
+            "deviceId": "LEAK1",
+            "friendlyId": "Utility room leak sensor",
+            "eeps": [{"eep": "F6-05-01"}],
+            "states": {"liquidDetected": False},
+        }
+        coord._pending_devices.add("LEAK1")
+
+        coord._finalize_discovery()
+
+        device = coord.devices["LEAK1"]
+        assert device.channels[0].liquid_detected is False
+        assert device.last_update_source == "discovery"
 
     def test_eeps_as_dict_from_flattened_mqtt(self, coord):
         """EEPs may arrive as a dict (from _set_nested_property indexing)."""

--- a/tests/test_enocean_device.py
+++ b/tests/test_enocean_device.py
@@ -45,6 +45,7 @@ class TestDeviceProperties:
             ("F6-02-01", "event"),
             ("F6-02-02", "event"),
             ("F6-03-01", "event"),
+            ("F6-05-01", "binary_sensor"),
         ],
     )
     def test_entity_type(self, make_device, eep, expected):
@@ -295,6 +296,37 @@ class TestUpdateFromTelegram:
         )
         assert dev.channels[0].energy == 1234.5
         assert dev.channels[0].power == 56.7
+
+    @pytest.mark.parametrize("value", [True, "true", " TRUE "])
+    def test_liquid_detected(self, make_telegram, value):
+        dev = self._device()
+        dev.update_from_telegram(
+            make_telegram([{"key": "liquidDetected", "value": value}])
+        )
+        assert dev.channels[0].liquid_detected is True
+
+    @pytest.mark.parametrize("value", [False, "false", " FALSE "])
+    def test_liquid_cleared(self, make_telegram, value):
+        dev = self._device()
+        dev.update_from_telegram(
+            make_telegram([{"key": "liquidDetected", "value": value}])
+        )
+        assert dev.channels[0].liquid_detected is False
+
+    def test_invalid_liquid_value_preserves_last_valid_state(self, make_telegram):
+        dev = self._device()
+        dev.update_from_telegram(
+            make_telegram([{"key": "liquidDetected", "value": True}])
+        )
+        dev.update_from_telegram(
+            make_telegram([{"key": "liquidDetected", "value": "unknown"}])
+        )
+        assert dev.channels[0].liquid_detected is True
+
+    def test_invalid_initial_liquid_value_remains_unknown(self, make_telegram):
+        dev = self._device()
+        dev.update_from_telegram(make_telegram([{"key": "liquidDetected", "value": 1}]))
+        assert dev.channels[0].liquid_detected is None
 
     def test_multi_channel_routing(self, make_telegram):
         dev = self._device()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.climate import HVACAction, HVACMode
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import UnitOfPower
@@ -13,6 +14,7 @@ from homeassistant.const import UnitOfPower
 from custom_components.opus_greennet import OpusGreenNetRuntimeData
 from custom_components.opus_greennet.binary_sensor import (
     OpusGreenNetBatterySensor,
+    OpusGreenNetMoistureSensor,
     OpusGreenNetProblemSensor,
     OpusGreenNetWindowSensor,
 )
@@ -275,6 +277,24 @@ def test_binary_sensor_values() -> None:
     assert battery.is_on is False
 
 
+def test_moisture_sensor_values_and_metadata() -> None:
+    coordinator = _coordinator()
+    device = _device("F6-05-01")
+    moisture = OpusGreenNetMoistureSensor(
+        coordinator, EAG_ID, GATEWAY_DEVICE_ID, device
+    )
+
+    assert moisture.is_on is None
+    assert moisture.device_class is BinarySensorDeviceClass.MOISTURE
+    assert moisture.unique_id == f"{EAG_ID}_DEV1_liquid_detected"
+
+    device.channels[0] = EnOceanChannel(channel_id=0, liquid_detected=True)
+    assert moisture.is_on is True
+
+    device.channels[0].liquid_detected = False
+    assert moisture.is_on is False
+
+
 def test_removes_obsolete_aggregate_when_channel_zero_exists() -> None:
     registry = MagicMock()
     registry.async_get_entity_id.side_effect = [
@@ -336,6 +356,7 @@ def test_keeps_single_channel_registry_entity() -> None:
         (async_setup_climate, "D1-4B-06", 1),
         (async_setup_sensors, "D1-4B-07", 3),
         (async_setup_binary_sensors, "D1-4B-05", 5),
+        (async_setup_binary_sensors, "F6-05-01", 1),
         (async_setup_events, "F6-02-01", 1),
     ],
 )


### PR DESCRIPTION
## Summary
- Add native Home Assistant moisture detection for F6-05-01 liquid leakage sensors
- Keep the initial state unknown until the bridge supplies an explicit valid wet or clear value
- Relates to #24

## Changes
- Map F6-05-01 devices to the binary sensor platform
- Parse the EnOcean `liquidDetected` function as a strict boolean and preserve the last valid state if malformed data arrives
- Add a moisture-class `Water leak` entity with stable device and unique-ID metadata
- Document the new supported profile and add its English entity translation
- Cover discovery, live MQTT updates, retained startup state, parsing safety, and entity behavior with tests

## Testing
- [x] `pytest -v --cov --cov-report=term-missing` passes (229 tests, 76.61% coverage)
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [ ] Manual testing: requested through the v0.3.1b0 beta after merge
